### PR TITLE
Missing images folder in fresh installs

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -135,8 +135,12 @@ blabla_ga()
 
 # HELPERS
 def get_images(extensions):
-    files = []
-    for f in os.listdir(os.path.join(now_project, "images")):
+    files, imagesPath  = [], os.path.join(now_project, "images")
+    try:
+        os.mkdir(imagesPath)
+    except OSError: #images folder already exists
+        pass
+    for f in os.listdir(imagesPath):
         for ext in extensions:
             if f.endswith(ext):
                 files.append(f)


### PR DESCRIPTION
Hi there!

Thanks for writing this tool! presskit() was already quite practical, but a static presskit makes more sense and is even easier to set up! Also, kudos for choosing Python and Jinja. <3

An exception is raised in _get_images_ (line 139) when listing the images. The problem is that _os.listdir_ can't list anything if the images folder doesn't exist, which is the case in a fresh install. 

Note that you won't notice anything if you've already generated a website, you need to get a fresh install, or at least to delete the images folder. I suppose you had manually created this folder while writing the script, which prevented you to realise the problem.

The solution is to try to create the folder with _os.mkdir_ before using _os.listdir_.

![error-os-listdir](https://cloud.githubusercontent.com/assets/720624/3402956/9ec9f92c-fd61-11e3-9f1e-a1e76f78f98c.png)  
